### PR TITLE
use is_a instead of string comparison for interface check

### DIFF
--- a/lib/Dwoo/Core.php
+++ b/lib/Dwoo/Core.php
@@ -643,8 +643,7 @@ class Core {
 			throw new Exception('Resource class does not exist');
 		}
 
-		$interfaces = class_implements($class);
-		if (in_array('ITemplate', $interfaces) === false) {
+		if (!is_a($class, '\Dwoo\ITemplate', true)) {
 			throw new Exception('Resource class must implement ITemplate');
 		}
 


### PR DESCRIPTION
In my PHP 5.5.3 system, this check failed because class_implements returned '\Dwoo\ITemplate' instead of 'ITemplate'.

I changed it to use the more appropriate is_a() function that PHP supplies for exactly this purpose, I expect it will work with PHP 5.4 as well
