### PR TITLE
Release 1.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 1.3.5 (2017-03-16)
+`Added`
+* Add new constant test from file `testShortClassConstants`.
+
+`Changed`
+* Update tests, add new test `testClassConstants`.
+* Update `Loader::rebuildClassPathCache` method, using `DirectoryIterator` class instead of `glob` function.
+
+`Fixed`
+* Fix class `BaseTests`, remove *cached* and *compiled* files when calling **destructor**.
+* Constants error when using 2 trailing slashes, issue [#63](https://github.com/dwoo-project/dwoo/issues/63).
+* Fix `parseConstKey` method, replacing double `\\` by single `\`.
+* Fix `throw new` exception, display on one line.
+
+`Removed`
+* Remove useless `else` and non accessing code.
+
 ## 1.3.4 (2017-03-07)
 `Added`
 * Add `docker-compose.yml` file for unit testing only.

--- a/lib/Dwoo/Compiler.php
+++ b/lib/Dwoo/Compiler.php
@@ -1208,7 +1208,6 @@ class Compiler implements ICompiler
             }
 
             throw new CompilationException($this, 'Syntax malformation, a block of type "' . $type . '" was closed but was not opened');
-            break;
         }
 
         return $output;
@@ -1708,9 +1707,9 @@ class Compiler implements ICompiler
 
         if ($curBlock === 'root' && substr($out, 0, strlen(self::PHP_OPEN)) !== self::PHP_OPEN) {
             return self::PHP_OPEN . 'echo ' . $out . ';' . self::PHP_CLOSE;
-        } else {
-            return $out;
         }
+
+        return $out;
     }
 
     /**
@@ -2261,9 +2260,9 @@ class Compiler implements ICompiler
             return $parsingParams;
         } elseif ($curBlock === 'namedparam') {
             return array($output, substr($srcOutput, 1, - 1));
-        } else {
-            return $output;
         }
+
+        return $output;
     }
 
     /**

--- a/lib/Dwoo/Compiler.php
+++ b/lib/Dwoo/Compiler.php
@@ -2305,9 +2305,9 @@ class Compiler implements ICompiler
             return $parsingParams;
         } elseif ($curBlock === 'namedparam') {
             return array($output, $m[1]);
-        } else {
-            return $output;
         }
+
+        return $output;
     }
 
     /**

--- a/lib/Dwoo/Compiler.php
+++ b/lib/Dwoo/Compiler.php
@@ -8,9 +8,9 @@
  * @author    David Sanchez <david38sanchez@gmail.com>
  * @copyright 2008-2013 Jordi Boggiano
  * @copyright 2013-2017 David Sanchez
- * @license   http://dwoo.org/LICENSE Modified BSD License
- * @version   1.3.4
- * @date      2017-03-01
+ * @license   http://dwoo.org/LICENSE LGPLv3
+ * @version   1.4.0
+ * @date      2017-03-16
  * @link      http://dwoo.org/
  */
 
@@ -2320,17 +2320,17 @@ class Compiler implements ICompiler
      */
     protected function parseConstKey($key, $curBlock)
     {
+        $key = str_replace('\\\\', '\\', $key);
+
         if ($this->securityPolicy !== null && $this->securityPolicy->getConstantHandling() === SecurityPolicy::CONST_DISALLOW) {
             return 'null';
         }
 
         if ($curBlock !== 'root') {
-            $output = '(defined("' . $key . '") ? ' . $key . ' : null)';
-        } else {
-            $output = $key;
+            return '(defined("' . $key . '") ? ' . $key . ' : null)';
         }
 
-        return $output;
+        return $key;
     }
 
     /**
@@ -2545,15 +2545,14 @@ class Compiler implements ICompiler
                 return $output;
             } elseif (isset($assign)) {
                 return self::PHP_OPEN . $output . ';' . self::PHP_CLOSE;
-            } else {
-                return $output;
             }
+
+            return $output;
         } else {
             if ($curBlock === 'string' || $curBlock === 'delimited_string') {
                 return array(0, '');
-            } else {
-                throw new CompilationException($this, 'Invalid variable name <em>' . $substr . '</em>');
             }
+            throw new CompilationException($this, 'Invalid variable name <em>' . $substr . '</em>');
         }
     }
 

--- a/lib/Dwoo/Core.php
+++ b/lib/Dwoo/Core.php
@@ -8,9 +8,9 @@
  * @author    David Sanchez <david38sanchez@gmail.com>
  * @copyright 2008-2013 Jordi Boggiano
  * @copyright 2013-2017 David Sanchez
- * @license   http://dwoo.org/LICENSE Modified BSD License
- * @version   1.3.4
- * @date      2017-03-01
+ * @license   http://dwoo.org/LICENSE LGPLv3
+ * @version   1.4.0
+ * @date      2017-03-16
  * @link      http://dwoo.org/
  */
 
@@ -329,10 +329,7 @@ class Core
             $_tpl = new TemplateFile($_tpl);
             $_tpl->setIncludePath($this->getTemplateDir());
         } else {
-            throw new Exception(
-                'Dwoo->get\'s first argument must be a ITemplate (i.e. TemplateFile) or 
-            a valid path to a template file', E_USER_NOTICE
-            );
+            throw new Exception('Dwoo->get\'s first argument must be a ITemplate (i.e. TemplateFile) or a valid path to a template file', E_USER_NOTICE);
         }
 
         // save the current template, enters render mode at the same time
@@ -347,10 +344,7 @@ class Core
         } elseif ($data instanceof ArrayAccess) {
             $this->data = $data;
         } else {
-            throw new Exception(
-                'Dwoo->get/Dwoo->output\'s data argument must be a IDataProvider object (i.e. Data) or
-            an associative array', E_USER_NOTICE
-            );
+            throw new Exception('Dwoo->get/Dwoo->output\'s data argument must be a IDataProvider object (i.e. Data) or an associative array', E_USER_NOTICE);
         }
 
         $this->addGlobal('template', $_tpl->getName());

--- a/lib/Dwoo/Loader.php
+++ b/lib/Dwoo/Loader.php
@@ -141,12 +141,10 @@ class Loader implements ILoader
                 } elseif (isset($this->classPath[$class . 'Compile'])) {
                     include_once $this->classPath[$class . 'Compile'];
                 } else {
-                    throw new Exception('Plugin "' . $class .
-                        '" can not be found, maybe you forgot to bind it if it\'s a custom plugin ?', E_USER_NOTICE);
+                    throw new Exception('Plugin "' . $class . '" can not be found, maybe you forgot to bind it if it\'s a custom plugin ?', E_USER_NOTICE);
                 }
             } else {
-                throw new Exception('Plugin "' . $class .
-                    '" can not be found, maybe you forgot to bind it if it\'s a custom plugin ?', E_USER_NOTICE);
+                throw new Exception('Plugin "' . $class . '" can not be found, maybe you forgot to bind it if it\'s a custom plugin ?', E_USER_NOTICE);
             }
         }
     }

--- a/lib/Dwoo/Loader.php
+++ b/lib/Dwoo/Loader.php
@@ -1,16 +1,16 @@
 <?php
 /**
- * Copyright (c) 2013-2016
+ * Copyright (c) 2013-2017
  *
  * @category  Library
  * @package   Dwoo
  * @author    Jordi Boggiano <j.boggiano@seld.be>
  * @author    David Sanchez <david38sanchez@gmail.com>
  * @copyright 2008-2013 Jordi Boggiano
- * @copyright 2013-2016 David Sanchez
- * @license   http://dwoo.org/LICENSE Modified BSD License
- * @version   1.3.0
- * @date      2016-09-23
+ * @copyright 2013-2017 David Sanchez
+ * @license   http://dwoo.org/LICENSE LGPLv3
+ * @version   1.4.0
+ * @date      2017-03-16
  * @link      http://dwoo.org/
  */
 
@@ -77,40 +77,26 @@ class Loader implements ILoader
     /**
      * Rebuilds class paths, scans the given directory recursively and saves all paths in the given file.
      *
-     * @param string $path      the plugin path to scan
-     * @param string $cacheFile the file where to store the plugin paths cache, it will be overwritten
+     * @param string         $path      the plugin path to scan
+     * @param string|boolean $cacheFile the file where to store the plugin paths cache, it will be overwritten
      *
      * @throws Exception
      */
     protected function rebuildClassPathCache($path, $cacheFile)
     {
+        $tmp = array();
         if ($cacheFile !== false) {
             $tmp             = $this->classPath;
             $this->classPath = array();
         }
 
         // iterates over all files/folders
-        $list = glob(rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . '*');
-        if (is_array($list)) {
-            foreach ($list as $f) {
-                if (is_dir($f)) {
-                    $this->rebuildClassPathCache($f, false);
+        foreach (new \DirectoryIterator($path) as $fileInfo) {
+            if (!$fileInfo->isDot()) {
+                if ($fileInfo->isDir()) {
+                    $this->rebuildClassPathCache($fileInfo->getPathname(), false);
                 } else {
-                    // TODO: is it still valid now?
-                    $this->classPath[str_replace(array(
-                        'function.',
-                        'block.',
-                        'modifier.',
-                        'outputfilter.',
-                        'filter.',
-                        'prefilter.',
-                        'postfilter.',
-                        'pre.',
-                        'post.',
-                        'output.',
-                        'shared.',
-                        'helper.'
-                    ), '', basename($f, '.php'))] = $f;
+                    $this->classPath[$fileInfo->getBasename('.php')] = $fileInfo->getPathname();
                 }
             }
         }
@@ -118,8 +104,7 @@ class Loader implements ILoader
         // save in file if it's the first call (not recursed)
         if ($cacheFile !== false) {
             if (!file_put_contents($cacheFile, serialize($this->classPath))) {
-                throw new Exception('Could not write into ' . $cacheFile .
-                    ', either because the folder is not there (create it) or because of the chmod configuration (please ensure this directory is writable by php), alternatively you can change the directory used with $dwoo->setCompileDir() or provide a custom loader object with $dwoo->setLoader()');
+                throw new Exception('Could not write into ' . $cacheFile . ', either because the folder is not there (create it) or because of the chmod configuration (please ensure this directory is writable by php), alternatively you can change the directory used with $dwoo->setCompileDir() or provide a custom loader object with $dwoo->setLoader()');
             }
             $this->classPath += $tmp;
         }

--- a/lib/Dwoo/Template/File.php
+++ b/lib/Dwoo/Template/File.php
@@ -8,9 +8,9 @@
  * @author    David Sanchez <david38sanchez@gmail.com>
  * @copyright 2008-2013 Jordi Boggiano
  * @copyright 2013-2017 David Sanchez
- * @license   http://dwoo.org/LICENSE Modified BSD License
+ * @license   http://dwoo.org/LICENSE LGPLv3
  * @version   1.4.0
- * @date      2017-03-09
+ * @date      2017-03-16
  * @link      http://dwoo.org/
  */
 
@@ -42,7 +42,7 @@ class File extends Str
      *
      * @var array
      */
-    protected $includePath = [];
+    protected $includePath = array();
 
     /**
      * Resolved path cache when looking for a file in multiple include paths.
@@ -66,7 +66,7 @@ class File extends Str
      *                            template from others, if null it defaults to the filename+bits of the path
      * @param mixed  $includePath a string for a single path to look into for the given file, or an array of paths
      */
-    public function __construct($file, $cacheTime = null, $cacheId = null, $compileId = null, $includePath = [])
+    public function __construct($file, $cacheTime = null, $cacheId = null, $compileId = null, $includePath = array())
     {
         parent::__construct($file, $cacheTime, $cacheId, $compileId);
         $this->template = null;
@@ -84,7 +84,7 @@ class File extends Str
     public function setIncludePath($paths)
     {
         if (is_array($paths) === false) {
-            $paths = [$paths];
+            $paths = array($paths);
         }
 
         $this->includePath  = $paths;
@@ -144,7 +144,7 @@ class File extends Str
     {
         if ($this->resolvedPath !== null) {
             return $this->resolvedPath;
-        } elseif (array_filter($this->getIncludePath()) == []) {
+        } elseif (array_filter($this->getIncludePath()) == array()) {
             return $this->file;
         } else {
             foreach ($this->getIncludePath() as $path) {
@@ -202,13 +202,13 @@ class File extends Str
                                            $compileId = null, ITemplate $parentTemplate = null)
     {
         if (DIRECTORY_SEPARATOR === '\\') {
-            $resourceId = str_replace(["\t", "\n", "\r", "\f", "\v"], [
+            $resourceId = str_replace(array("\t", "\n", "\r", "\f", "\v"), array(
                 '\\t',
                 '\\n',
                 '\\r',
                 '\\f',
                 '\\v'
-            ], $resourceId);
+            ), $resourceId);
         }
         $resourceId = strtr($resourceId, '\\', '/');
 

--- a/lib/Dwoo/Template/Str.php
+++ b/lib/Dwoo/Template/Str.php
@@ -8,9 +8,9 @@
  * @author    David Sanchez <david38sanchez@gmail.com>
  * @copyright 2008-2013 Jordi Boggiano
  * @copyright 2013-2017 David Sanchez
- * @license   http://dwoo.org/LICENSE Modified BSD License
+ * @license   http://dwoo.org/LICENSE LGPLv3
  * @version   1.4.0
- * @date      2017-03-09
+ * @date      2017-03-16
  * @link      http://dwoo.org/
  */
 
@@ -77,10 +77,10 @@ class Str implements ITemplate
      *
      * @var array
      */
-    protected static $cache = [
-        'cached'   => [],
-        'compiled' => []
-    ];
+    protected static $cache = array(
+        'cached'   => array(),
+        'compiled' => array()
+    );
 
     /**
      * Holds the compiler that built this template.
@@ -370,7 +370,7 @@ class Str implements ITemplate
             if ($compiler === null) {
                 $compiler = $core->getDefaultCompilerFactory($this->getResourceName());
 
-                if ($compiler === null || $compiler === ['Dwoo\Compiler', 'compilerFactory']) {
+                if ($compiler === null || $compiler === array('Dwoo\Compiler', 'compilerFactory')) {
                     $compiler = Compiler::compilerFactory();
                 } else {
                     $compiler = call_user_func($compiler);

--- a/tests/BaseTests.php
+++ b/tests/BaseTests.php
@@ -41,10 +41,9 @@ namespace Dwoo\Tests
         }
 
         /**
-         * Tears down the fixture, for example, close a network connection.
-         * This method is called after a test is executed.
+         * Clear cache and compiled directories
          */
-        protected function tearDown()
+        public function __destruct()
         {
             $this->clearDir($this->cacheDir, true);
             $this->clearDir($this->compileDir, true);
@@ -63,7 +62,7 @@ namespace Dwoo\Tests
                 if (!$emptyOnly) {
                     rmdir($path);
                 }
-            } else {
+            } elseif (is_file($path)) {
                 unlink($path);
             }
         }

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -282,10 +282,10 @@ replace="BAR"
             if (!defined('TEST')) {
                 define('TEST', 'Test');
             }
-            $tpl = new TemplateString('{$dwoo.const.TEST} {$dwoo.const.Dwoo\\Core::FUNC_PLUGIN*$dwoo.const.Dwoo\\Core::BLOCK_PLUGIN}');
+            $tpl = new TemplateString('{$dwoo.const.TEST}');
             $tpl->forceCompilation();
 
-            $this->assertEquals(TEST . ' ' . (Core::FUNC_PLUGIN * Core::BLOCK_PLUGIN), $this->dwoo->get($tpl, array(), $this->compiler));
+            $this->assertEquals(TEST, $this->dwoo->get($tpl, array(), $this->compiler));
         }
 
         public function testShortConstants()
@@ -297,6 +297,17 @@ replace="BAR"
             $tpl->forceCompilation();
 
             $this->assertEquals(TEST . ' ' . (PHP_MAJOR_VERSION * PHP_MINOR_VERSION), $this->dwoo->get($tpl, array(), $this->compiler));
+        }
+
+        public function testClassConstants()
+        {
+            $tpl = new TemplateString('{$dwoo.const.Dwoo\Core::FUNC_PLUGIN*$dwoo.const.Dwoo\Core::BLOCK_PLUGIN}');
+            $tpl->forceCompilation();
+            $this->assertEquals((Core::FUNC_PLUGIN * Core::BLOCK_PLUGIN), $this->dwoo->get($tpl, array(), $this->compiler));
+
+            $tpl = new TemplateString('{$dwoo.const.Dwoo\\Core::FUNC_PLUGIN*$dwoo.const.Dwoo\\Core::BLOCK_PLUGIN}');
+            $tpl->forceCompilation();
+            $this->assertEquals((Core::FUNC_PLUGIN * Core::BLOCK_PLUGIN), $this->dwoo->get($tpl, array(), $this->compiler));
         }
 
         public function testShortClassConstants()

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -7,6 +7,7 @@ namespace Dwoo\Tests
     use Dwoo\Core;
     use PluginHelper;
     use Dwoo\Template\Str as TemplateString;
+    use Dwoo\Template\File as TemplateFile;
     use Dwoo\Security\Policy as SecurityPolicy;
 
     /**
@@ -308,6 +309,10 @@ replace="BAR"
             $tpl = new TemplateString('{$dwoo.const.Dwoo\\Core::FUNC_PLUGIN*$dwoo.const.Dwoo\\Core::BLOCK_PLUGIN}');
             $tpl->forceCompilation();
             $this->assertEquals((Core::FUNC_PLUGIN * Core::BLOCK_PLUGIN), $this->dwoo->get($tpl, array(), $this->compiler));
+
+            $tpl = new TemplateFile(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'resources' . DIRECTORY_SEPARATOR . 'constants.html');
+            $tpl->forceCompilation();
+            $this->assertEquals((Core::FUNC_PLUGIN * Core::BLOCK_PLUGIN) . "\n" . (Core::FUNC_PLUGIN * Core::BLOCK_PLUGIN), $this->dwoo->get($tpl, array(), $this->compiler));
         }
 
         public function testShortClassConstants()

--- a/tests/resources/constants.html
+++ b/tests/resources/constants.html
@@ -1,0 +1,2 @@
+{$dwoo.const.Dwoo\Core::FUNC_PLUGIN*$dwoo.const.Dwoo\Core::BLOCK_PLUGIN}
+{$dwoo.const.Dwoo\\Core::FUNC_PLUGIN*$dwoo.const.Dwoo\\Core::BLOCK_PLUGIN}


### PR DESCRIPTION
Update master to 1.3.5 release:

`Added`
* Add new constant test from file `testShortClassConstants`.

`Changed`
* Update tests, add new test `testClassConstants`.
* Update `Loader::rebuildClassPathCache` method, using `DirectoryIterator` class instead of `glob` function.

`Fixed`
* Fix class `BaseTests`, remove *cached* and *compiled* files when calling **destructor**.
* Constants error when using 2 trailing slashes, issue [#63](https://github.com/dwoo-project/dwoo/issues/63).
* Fix `parseConstKey` method, replacing double `\\` by single `\`.
* Fix `throw new` exception, display on one line.

`Removed`
* Remove useless `else` and non accessing code.