### PR TITLE
Release 1.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.3.6 (2017-03-27)
+`Changed`
+* In `setCacheDir` and `setCompileDir` methods, create directory path if not exist if possible.
+* Rename `Compiler::getDwoo()` to `Compiler::getCore()`.
+
+`Fixed`
+* Fix bug, using object for custom plugin and using `getobjectPlugin` method.
+* Fix error, `getCore` need to return `$this->core`.
+* Fix output data bug in `replaceModifiers` method.
+* Fix `addPlugin` method, add code when passing object in `$callback`.
+
 ## 1.3.5 (2017-03-16)
 `Added`
 * Add new constant test from file `testShortClassConstants`.

--- a/lib/Dwoo/Compilation/Exception.php
+++ b/lib/Dwoo/Compilation/Exception.php
@@ -1,16 +1,16 @@
 <?php
 /**
- * Copyright (c) 2013-2016
+ * Copyright (c) 2013-2017
  *
  * @category  Library
  * @package   Dwoo\Compilation
  * @author    Jordi Boggiano <j.boggiano@seld.be>
  * @author    David Sanchez <david38sanchez@gmail.com>
  * @copyright 2008-2013 Jordi Boggiano
- * @copyright 2013-2016 David Sanchez
- * @license   http://dwoo.org/LICENSE Modified BSD License
- * @version   1.3.0
- * @date      2016-09-23
+ * @copyright 2013-2017 David Sanchez
+ * @license   http://dwoo.org/LICENSE LGPLv3
+ * @version   1.3.6
+ * @date      2017-03-21
  * @link      http://dwoo.org/
  */
 
@@ -38,7 +38,7 @@ class Exception extends DwooException
     public function __construct(DwooCompiler $compiler, $message)
     {
         $this->compiler = $compiler;
-        $this->template = $compiler->getDwoo()->getTemplate();
+        $this->template = $compiler->getCore()->getTemplate();
         parent::__construct('Compilation error at line ' . $compiler->getLine() . ' in "' . $this->template->getResourceName() . ':' . $this->template->getResourceIdentifier() . '" : ' . $message);
     }
 

--- a/lib/Dwoo/Compiler.php
+++ b/lib/Dwoo/Compiler.php
@@ -10,7 +10,7 @@
  * @copyright 2013-2017 David Sanchez
  * @license   http://dwoo.org/LICENSE LGPLv3
  * @version   1.3.6
- * @date      2017-03-21
+ * @date      2017-03-22
  * @link      http://dwoo.org/
  */
 
@@ -2066,6 +2066,9 @@ class Compiler implements ICompiler
                     if (!is_array($callback)) {
                         if (!method_exists($callback, 'process')) {
                             throw new Exception('Custom plugin ' . $func . ' must implement the "process" method to be usable, or you should provide a full callback to the method to use');
+                        }
+                        if (is_object($callback)) {
+                            $callback = get_class($callback);
                         }
                         if (($ref = new ReflectionMethod($callback, 'process')) && $ref->isStatic()) {
                             $output = 'call_user_func(array(\'' . $callback . '\', \'process\'), ' . $params . ')';

--- a/lib/Dwoo/Compiler.php
+++ b/lib/Dwoo/Compiler.php
@@ -652,7 +652,7 @@ class Compiler implements ICompiler
      */
     public function getCore()
     {
-        return $this->dwoo;
+        return $this->core;
     }
 
     /**

--- a/lib/Dwoo/Core.php
+++ b/lib/Dwoo/Core.php
@@ -9,7 +9,7 @@
  * @copyright 2008-2013 Jordi Boggiano
  * @copyright 2013-2017 David Sanchez
  * @license   http://dwoo.org/LICENSE LGPLv3
- * @version   1.4.0
+ * @version   1.3.6
  * @date      2017-03-21
  * @link      http://dwoo.org/
  */

--- a/lib/Dwoo/Core.php
+++ b/lib/Dwoo/Core.php
@@ -534,10 +534,7 @@ class Core
                     'callback' => $callback
                 );
             } else {
-                throw new Exception(
-                    'Callback could not be processed correctly, please check that the function/class 
-                you used exists'
-                );
+                throw new Exception('Callback could not be processed correctly, please check that the function/class you used exists');
             }
         } elseif ($callback instanceof Closure) {
             $this->plugins[$name] = array(
@@ -545,10 +542,7 @@ class Core
                 'callback' => $callback
             );
         } else {
-            throw new Exception(
-                'Callback could not be processed correctly, please check that the function/class you 
-            used exists'
-            );
+            throw new Exception('Callback could not be processed correctly, please check that the function/class you used exists');
         }
     }
 
@@ -586,16 +580,9 @@ class Core
                 }
                 catch (Exception $e) {
                     if (strstr($callback, self::NAMESPACE_PLUGINS_FILTERS)) {
-                        throw new Exception(
-                            'Wrong filter name : ' . $callback . ', the "Filter" prefix should 
-                        not be used, please only use "' . str_replace('Filter', '', $callback) . '"'
-                        );
+                        throw new Exception('Wrong filter name : ' . $callback . ', the "Filter" prefix should not be used, please only use "' . str_replace('Filter', '', $callback) . '"');
                     } else {
-                        throw new Exception(
-                            'Wrong filter name : ' . $callback . ', when using autoload the filter must
-                         be in one of your plugin dir as "name.php" containig a class or function named
-                         "Filter<name>"'
-                        );
+                        throw new Exception('Wrong filter name : ' . $callback . ', when using autoload the filter must be in one of your plugin dir as "name.php" containig a class or function named "Filter<name>"');
                     }
                 }
             }
@@ -605,10 +592,7 @@ class Core
             } elseif (function_exists($class)) {
                 $callback = $class;
             } else {
-                throw new Exception(
-                    'Wrong filter name : ' . $callback . ', when using autoload the filter must be in
-                one of your plugin dir as "name.php" containig a class or function named "Filter<name>"'
-                );
+                throw new Exception('Wrong filter name : ' . $callback . ', when using autoload the filter must be in one of your plugin dir as "name.php" containig a class or function named "Filter<name>"');
             }
 
             $this->filters[] = $callback;

--- a/lib/Dwoo/Core.php
+++ b/lib/Dwoo/Core.php
@@ -10,7 +10,7 @@
  * @copyright 2013-2017 David Sanchez
  * @license   http://dwoo.org/LICENSE LGPLv3
  * @version   1.3.6
- * @date      2017-03-21
+ * @date      2017-03-22
  * @link      http://dwoo.org/
  */
 
@@ -772,6 +772,9 @@ class Core
     public function setCacheDir($dir)
     {
         $this->cacheDir = rtrim($dir, '/\\') . DIRECTORY_SEPARATOR;
+        if (!file_exists($this->cacheDir)) {
+            mkdir($this->cacheDir, 0777, true);
+        }
         if (is_writable($this->cacheDir) === false) {
             throw new Exception('The cache directory must be writable, chmod "' . $this->cacheDir . '" to make it writable');
         }
@@ -802,6 +805,9 @@ class Core
     public function setCompileDir($dir)
     {
         $this->compileDir = rtrim($dir, '/\\') . DIRECTORY_SEPARATOR;
+        if (!file_exists($this->compileDir)) {
+            mkdir($this->compileDir, 0777, true);
+        }
         if (is_writable($this->compileDir) === false) {
             throw new Exception('The compile directory must be writable, chmod "' . $this->compileDir . '" to make it writable');
         }

--- a/lib/Dwoo/Core.php
+++ b/lib/Dwoo/Core.php
@@ -10,7 +10,7 @@
  * @copyright 2013-2017 David Sanchez
  * @license   http://dwoo.org/LICENSE LGPLv3
  * @version   1.3.6
- * @date      2017-03-22
+ * @date      2017-03-23
  * @link      http://dwoo.org/
  */
 
@@ -49,7 +49,7 @@ class Core
      *
      * @var string
      */
-    const VERSION = '1.3.4';
+    const VERSION = '1.3.6';
 
     /**
      * Unique number of this dwoo release, based on version number.
@@ -57,7 +57,7 @@ class Core
      * has been compiled before this release or not, so that old templates are
      * recompiled automatically when Dwoo is updated
      */
-    const RELEASE_TAG = 134;
+    const RELEASE_TAG = 136;
 
     /**
      * Constants that represents all plugin types

--- a/lib/Dwoo/Core.php
+++ b/lib/Dwoo/Core.php
@@ -10,7 +10,7 @@
  * @copyright 2013-2017 David Sanchez
  * @license   http://dwoo.org/LICENSE LGPLv3
  * @version   1.4.0
- * @date      2017-03-16
+ * @date      2017-03-21
  * @link      http://dwoo.org/
  */
 
@@ -541,6 +541,21 @@ class Core
                 'type'     => self::FUNC_PLUGIN | $compilable,
                 'callback' => $callback
             );
+        } elseif (is_object($callback)) {
+            if (is_subclass_of($callback, 'Dwoo\Block\Plugin')) {
+                $this->plugins[$name] = array(
+                    'type'     => self::BLOCK_PLUGIN | $compilable,
+                    'callback' => get_class($callback),
+                    'class'    => $callback
+                );
+            } else {
+                $this->plugins[$name] = array(
+                    'type'     => self::CLASS_PLUGIN | $compilable,
+                    'callback' => $callback,
+                    'class'    => $callback,
+                    'function' => ($compilable ? 'compile' : 'process')
+                );
+            }
         } else {
             throw new Exception('Callback could not be processed correctly, please check that the function/class you used exists');
         }

--- a/lib/Dwoo/ICompiler.php
+++ b/lib/Dwoo/ICompiler.php
@@ -1,16 +1,16 @@
 <?php
 /**
- * Copyright (c) 2013-2016
+ * Copyright (c) 2013-2017
  *
  * @category  Library
  * @package   Dwoo
  * @author    Jordi Boggiano <j.boggiano@seld.be>
  * @author    David Sanchez <david38sanchez@gmail.com>
  * @copyright 2008-2013 Jordi Boggiano
- * @copyright 2013-2016 David Sanchez
- * @license   http://dwoo.org/LICENSE Modified BSD License
- * @version   1.3.0
- * @date      2016-09-23
+ * @copyright 2013-2017 David Sanchez
+ * @license   http://dwoo.org/LICENSE LGPLv3
+ * @version   1.3.6
+ * @date      2017-03-21
  * @link      http://dwoo.org/
  */
 
@@ -32,12 +32,12 @@ interface ICompiler
     /**
      * Compiles the provided string down to php code.
      *
-     * @param Core      $dwoo
+     * @param Core      $core
      * @param ITemplate $template the template to compile
      *
      * @return string a compiled php code string
      */
-    public function compile(Core $dwoo, ITemplate $template);
+    public function compile(Core $core, ITemplate $template);
 
     /**
      * Adds the custom plugins loaded into Dwoo to the compiler so it can load them.

--- a/lib/Dwoo/Plugins/Blocks/PluginSmartyinterface.php
+++ b/lib/Dwoo/Plugins/Blocks/PluginSmartyinterface.php
@@ -1,16 +1,16 @@
 <?php
 /**
- * Copyright (c) 2013-2016
+ * Copyright (c) 2013-2017
  *
  * @category  Library
  * @package   Dwoo\Plugins\Blocks
  * @author    Jordi Boggiano <j.boggiano@seld.be>
  * @author    David Sanchez <david38sanchez@gmail.com>
  * @copyright 2008-2013 Jordi Boggiano
- * @copyright 2013-2016 David Sanchez
- * @license   http://dwoo.org/LICENSE Modified BSD License
- * @version   1.3.0
- * @date      2016-09-19
+ * @copyright 2013-2017 David Sanchez
+ * @license   http://dwoo.org/LICENSE LGPLv3
+ * @version   1.3.6
+ * @date      2017-03-21
  * @link      http://dwoo.org/
  */
 
@@ -54,7 +54,7 @@ class PluginSmartyinterface extends BlockPlugin implements ICompilableBlock
         $params     = $params['*'];
 
         if ($pluginType & Core::CUSTOM_PLUGIN) {
-            $customPlugins = $compiler->getDwoo()->getCustomPlugins();
+            $customPlugins = $compiler->getCore()->getCustomPlugins();
             $callback      = $customPlugins[$func]['callback'];
             if (is_array($callback)) {
                 if (is_object($callback[0])) {

--- a/lib/Dwoo/Plugins/Functions/PluginExtends.php
+++ b/lib/Dwoo/Plugins/Functions/PluginExtends.php
@@ -1,16 +1,16 @@
 <?php
 /**
- * Copyright (c) 2013-2016
+ * Copyright (c) 2013-2017
  *
  * @category  Library
  * @package   Dwoo\Plugins\Functions
  * @author    Jordi Boggiano <j.boggiano@seld.be>
  * @author    David Sanchez <david38sanchez@gmail.com>
  * @copyright 2008-2013 Jordi Boggiano
- * @copyright 2013-2016 David Sanchez
- * @license   http://dwoo.org/LICENSE Modified BSD License
- * @version   1.3.0
- * @date      2016-09-19
+ * @copyright 2013-2017 David Sanchez
+ * @license   http://dwoo.org/LICENSE LGPLv3
+ * @version   1.3.6
+ * @date      2017-03-21
  * @link      http://dwoo.org/
  */
 
@@ -75,8 +75,8 @@ class PluginExtends extends Plugin implements ICompilable
             self::$r = '\s*' . self::$r;
         }
         $inheritanceTree = array(array('source' => $compiler->getTemplateSource()));
-        $curPath         = dirname($compiler->getDwoo()->getTemplate()->getResourceIdentifier()) . DIRECTORY_SEPARATOR;
-        $curTpl          = $compiler->getDwoo()->getTemplate();
+        $curPath         = dirname($compiler->getCore()->getTemplate()->getResourceIdentifier()) . DIRECTORY_SEPARATOR;
+        $curTpl          = $compiler->getCore()->getTemplate();
 
         while (!empty($file)) {
             if ($file === '""' || $file === "''" || (substr($file, 0, 1) !== '"' && substr($file, 0, 1) !== '\'')) {
@@ -94,7 +94,7 @@ class PluginExtends extends Plugin implements ICompilable
             }
 
             try {
-                $parent = $compiler->getDwoo()->templateFactory($resource, $identifier, null, null, null, $curTpl);
+                $parent = $compiler->getCore()->templateFactory($resource, $identifier, null, null, null, $curTpl);
             }
             catch (SecurityException $e) {
                 throw new CompilationException($compiler, 'Extends : Security restriction : ' . $e->getMessage());

--- a/lib/Dwoo/Plugins/Functions/PluginExtendsCheck.php
+++ b/lib/Dwoo/Plugins/Functions/PluginExtendsCheck.php
@@ -8,9 +8,9 @@
  * @author    David Sanchez <david38sanchez@gmail.com>
  * @copyright 2008-2013 Jordi Boggiano
  * @copyright 2013-2017 David Sanchez
- * @license   http://dwoo.org/LICENSE Modified BSD License
- * @version   1.3.2
- * @date      2017-01-06
+ * @license   http://dwoo.org/LICENSE LGPLv3
+ * @version   1.3.6
+ * @date      2017-03-21
  * @link      http://dwoo.org/
  */
 
@@ -41,7 +41,7 @@ class PluginExtendsCheck extends Plugin implements ICompilable
         $resource   = $m[1];
         $identifier = $m[2];
 
-        $tpl = $compiler->getDwoo()->templateFactory($resource, $identifier);
+        $tpl = $compiler->getCore()->templateFactory($resource, $identifier);
 
         if ($tpl === null) {
             throw new CompilationException($compiler,

--- a/lib/Dwoo/Plugins/Functions/PluginLoadTemplates.php
+++ b/lib/Dwoo/Plugins/Functions/PluginLoadTemplates.php
@@ -8,9 +8,9 @@
  * @author    David Sanchez <david38sanchez@gmail.com>
  * @copyright 2008-2013 Jordi Boggiano
  * @copyright 2013-2017 David Sanchez
- * @license   http://dwoo.org/LICENSE Modified BSD License
- * @version   1.3.2
- * @date      2017-01-06
+ * @license   http://dwoo.org/LICENSE LGPLv3
+ * @version   1.3.6
+ * @date      2017-03-21
  * @link      http://dwoo.org/
  */
 
@@ -52,11 +52,11 @@ class PluginLoadTemplates extends Plugin implements ICompilable
             $identifier = $m[2];
         } else {
             // get the current template's resource
-            $resource   = $compiler->getDwoo()->getTemplate()->getResourceName();
+            $resource   = $compiler->getCore()->getTemplate()->getResourceName();
             $identifier = $file;
         }
 
-        $tpl = $compiler->getDwoo()->templateFactory($resource, $identifier);
+        $tpl = $compiler->getCore()->templateFactory($resource, $identifier);
 
         if ($tpl === null) {
             throw new CompilationException($compiler,
@@ -67,7 +67,7 @@ class PluginLoadTemplates extends Plugin implements ICompilable
         }
 
         $cmp = clone $compiler;
-        $cmp->compile($compiler->getDwoo(), $tpl);
+        $cmp->compile($compiler->getCore(), $tpl);
         foreach ($cmp->getTemplatePlugins() as $template => $args) {
             $compiler->addTemplatePlugin($template, $args['params'], $args['uuid'], $args['body']);
         }

--- a/lib/Dwoo/Plugins/Functions/PluginTif.php
+++ b/lib/Dwoo/Plugins/Functions/PluginTif.php
@@ -8,9 +8,9 @@
  * @author    David Sanchez <david38sanchez@gmail.com>
  * @copyright 2008-2013 Jordi Boggiano
  * @copyright 2013-2017 David Sanchez
- * @license   http://dwoo.org/LICENSE Modified BSD License
- * @version   1.3.2
- * @date      2017-01-06
+ * @license   http://dwoo.org/LICENSE LGPLv3
+ * @version   1.3.6
+ * @date      2017-03-21
  * @link      http://dwoo.org/
  */
 
@@ -49,7 +49,7 @@ class PluginTif extends Plugin implements ICompilable
         // load if plugin
         if (!class_exists(Core::NAMESPACE_PLUGINS_BLOCKS . 'PluginIf')) {
             try {
-                $compiler->getDwoo()->getLoader()->loadPlugin('if');
+                $compiler->getCore()->getLoader()->loadPlugin('if');
             }
             catch (Exception $e) {
                 throw new CompilationException($compiler, 'Tif: the if plugin is required to use Tif');


### PR DESCRIPTION
Update master to 1.3.6 release:

`Changed`
* In `setCacheDir` and `setCompileDir` methods, create directory path if not exist if possible.
* Rename `Compiler::getDwoo()` to `Compiler::getCore()`.

`Fixed`
* Fix bug, using object for custom plugin and using `getobjectPlugin` method.
* Fix error, `getCore` need to return `$this->core`.
* Fix output data bug in `replaceModifiers` method.
* Fix `addPlugin` method, add code when passing object in `$callback`.