### PR TITLE
Support including a template that is inherited from a relative parent 

### DIFF
--- a/lib/Dwoo/Template/File.php
+++ b/lib/Dwoo/Template/File.php
@@ -83,7 +83,9 @@ class File extends Str
      */
     public function setIncludePath($paths)
     {
-        if (is_array($paths) === false) {
+        if ($paths == null) {
+          $paths = array();
+        } elseif (is_array($paths) === false) {
             $paths = array($paths);
         }
 

--- a/tests/BlockTest.php
+++ b/tests/BlockTest.php
@@ -256,6 +256,19 @@ Root Footer
 '));
         }
 
+        public function testIncludeExtended()
+        {
+            $tpl = new TemplateFile(dirname(__FILE__) . '/resources/include_extended/including.html');
+            $tpl->forceCompilation();
+
+            $this->assertEquals($this->dwoo->get($tpl, array(), $this->compiler),"<html>
+<div>Extended</div>
+
+</html>
+");
+
+        }
+
         public function testIf()
         {
             $tpl = new TemplateString('{if "BAR"==reverse($foo|reverse|upper)}true{/if}');

--- a/tests/resources/include_extended/extended/extended.html
+++ b/tests/resources/include_extended/extended/extended.html
@@ -1,0 +1,4 @@
+{extends "../root.html"}
+{block "content"}
+Extended
+{/block}

--- a/tests/resources/include_extended/including.html
+++ b/tests/resources/include_extended/including.html
@@ -1,0 +1,3 @@
+<html>
+{include "tests/resources/include_extended/extended/extended.html"}
+</html>

--- a/tests/resources/include_extended/root.html
+++ b/tests/resources/include_extended/root.html
@@ -1,0 +1,1 @@
+<div>{block "content"}Root{/block}</div>


### PR DESCRIPTION
Currently, if a template includes template via an absolute path that is inherited, and the parent of the inherited template is linked relatively e.g. `{extends "../root.html"}`, an exception is thrown:

`
Dwoo\Compilation\Exception: Compilation error at line 1 in "file:tests/resources/include_extended/extended/extended.html" : Extends : When using an include path you can not reference a template into a parent directory (using ../)
`
Example:

`including.html`:
```html
<html>
{include "some/path/extended/extended.html"}
</html>
```
`some/path/extended/extended.html`:
```html
{extends "../root.html"}
{block "content"}Extended{/block}
```

`some/path/root.html`:
```html
<div>{block "content"}Root{/block}</div>
```


This constellation leads to calling `Dwoo\Template\File::setIncludePath($paths)` with a null argument and results in the `includePath` attribute holding an array with a single null element `[0=>null]`
instead of an empty array, which this PR proposes.

This is affects `Dwoo\Template\File::templateFactory`: 
```php
if ($includePath = $parentTemplate->getIncludePath()) {
``` 
and throws the mentioned exception.

I have also included a test case for this constellation. 