### PR TITLE
Fix rehashing race condition in Loader::addDirectory

### DIFF
--- a/lib/Dwoo/Loader.php
+++ b/lib/Dwoo/Loader.php
@@ -180,9 +180,15 @@ class Loader implements ILoader
         $cacheFile = $this->cacheDir . 'classpath-' . substr(strtr($pluginDir, '/\\:' . PATH_SEPARATOR, '----'),
                 strlen($pluginDir) > 80 ? - 80 : 0) . '.d' . Core::RELEASE_TAG . '.php';
         $this->paths[$pluginDir] = $cacheFile;
+
+        $chachedClassPath = null;
+
         if (file_exists($cacheFile)) {
-            $classpath       = file_get_contents($cacheFile);
-            $this->classPath = unserialize($classpath) + $this->classPath;
+            $chachedClassPath = unserialize(file_get_contents($cacheFile));
+        }
+
+        if (is_array($chachedClassPath)) {
+            $this->classPath = $chachedClassPath + $this->classPath;
         } else {
             $this->rebuildClassPathCache($pluginDir, $cacheFile);
         }


### PR DESCRIPTION
Follow up of #84 
Also checks in `Loader::addDirectory` if un-serialized (cached) class path is really an array before using it.