### PR TITLE
Exclude plugin uuid from template function name

### DIFF
--- a/lib/Dwoo/Compiler.php
+++ b/lib/Dwoo/Compiler.php
@@ -533,9 +533,11 @@ class Dwoo_Compiler implements Dwoo_ICompiler
      * @param string $uuid   unique id of the function
      * @param string $body   function php code
      */
-    public function addTemplatePlugin($name, array $params, $uuid, $body = null)
+    public function addTemplatePlugin($name, array $params, $uuid, $body = null, Dwoo_ITemplate $sourceTpl = null)
     {
-        $this->templatePlugins[$name] = array('params' => $params, 'body' => $body, 'uuid' => $uuid);
+        if (!array_key_exists($name, $this->templatePlugins) || $this->templatePlugins[$name]['uuid'] == $uuid) {
+            $this->templatePlugins[$name] = array('params'=> $params, 'body' => $body, 'uuid' => $uuid, 'sourceTpl' => $sourceTpl);
+        }
     }
 
     /**
@@ -2031,7 +2033,7 @@ class Dwoo_Compiler implements Dwoo_ICompiler
         } elseif ($pluginType & Dwoo_Core::TEMPLATE_PLUGIN) {
             array_unshift($params, '$this');
             $params = self::implode_r($params);
-            $output = 'Dwoo_Plugin_'.$func.'_'.$this->templatePlugins[$func]['uuid'].'('.$params.')';
+            $output = 'Dwoo_Plugin_'.$func.'('.$params.')';
             $this->templatePlugins[$func]['called'] = true;
         }
 

--- a/lib/Dwoo/Template/String.php
+++ b/lib/Dwoo/Template/String.php
@@ -381,7 +381,7 @@ class Dwoo_Template_String implements Dwoo_ITemplate
 
             if (extension_loaded('Zend OPcache')) {
                 opcache_invalidate($compiledFile);
-            } elseif (extension_loaded('apc') && ini_get('apc.enabled')) {
+            } elseif (function_exists('apc_compile_file')) {
                 apc_compile_file($compiledFile);
             }
 

--- a/lib/Dwoo/Template/String.php
+++ b/lib/Dwoo/Template/String.php
@@ -382,7 +382,7 @@ class Dwoo_Template_String implements Dwoo_ITemplate
             if (extension_loaded('Zend OPcache')) {
                 opcache_invalidate($compiledFile);
             } elseif (extension_loaded('apc') && ini_get('apc.enabled')) {
-                apc_delete_file($compiledFile);
+                apc_compile_file($compiledFile);
             }
 
             self::$cache['compiled'][$this->compileId] = true;

--- a/lib/plugins/builtin/blocks/template.php
+++ b/lib/plugins/builtin/blocks/template.php
@@ -71,7 +71,7 @@ class Dwoo_Plugin_template extends Dwoo_Block_Plugin implements Dwoo_ICompilable
         }
         $init .= '/* -- template start output */';
 
-        $funcName = 'Dwoo_Plugin_'.$params['name'].'_'.$params['uuid'];
+        $funcName = 'Dwoo_Plugin_'.$params['name'];
 
         $search = array(
             '$this->charset',

--- a/lib/plugins/builtin/functions/load_templates.php
+++ b/lib/plugins/builtin/functions/load_templates.php
@@ -47,30 +47,46 @@ function Dwoo_Plugin_load_templates_compile(Dwoo_Compiler $compiler, $file)
 
     $cmp = clone $compiler;
     $cmp->compile($compiler->getDwoo(), $tpl);
-    foreach ($cmp->getTemplatePlugins() as $template => $args) {
-        $compiler->addTemplatePlugin($template, $args['params'], $args['uuid'], $args['body']);
+    $usedTemplates = array($tpl);
+    foreach ($cmp->getTemplatePlugins() as $template=>$args) {
+        if (isset($args['sourceTpl'])) {
+            $sourceTpl = $args['sourceTpl'];
+        } else {
+            $sourceTpl = $tpl;
+        }
+
+        $compiler->addTemplatePlugin($template, $args['params'], $args['uuid'], $args['body'], $sourceTpl);
+
+        if (!in_array($sourceTpl, $usedTemplates, true)) {
+            $usedTemplates[] = $sourceTpl;
+        }
     }
-    foreach ($cmp->getUsedPlugins() as $plugin => $type) {
+    foreach ($cmp->getUsedPlugins() as $plugin=>$type) {
         $compiler->addUsedPlugin($plugin, $type);
     }
 
     $out = '\'\';// checking for modification in '.$resource.':'.$identifier."\r\n";
 
-    $modCheck = $tpl->getIsModifiedCode();
+    foreach ($usedTemplates AS $usedTemplate) {
+        $modCheck = $usedTemplate->getIsModifiedCode();
 
-    if ($modCheck) {
-        $out .= 'if (!('.$modCheck.')) { ob_end_clean(); return false; }';
-    } else {
-        $out .= 'try {
-	$tpl = $this->templateFactory("'.$resource.'", "'.$identifier.'");
+        if ($modCheck) {
+            $out .= 'if (!('.$modCheck.')) { ob_end_clean(); return false; }';
+        } else {
+            $usedTemplateResourceName = $usedTemplate->getResourceName();
+            $usedTemplateResourceIdentifier = $usedTemplate->getResourceIdentifier();
+            $out .= '
+try {
+	$tpl = $this->templateFactory("'.$usedTemplateResourceName.'", "'.$usedTemplateResourceIdentifier.'");
 } catch (Dwoo_Exception $e) {
-	$this->triggerError(\'Load Templates : Resource <em>'.$resource.'</em> was not added to Dwoo, can not extend <em>'.$identifier.'</em>\', E_USER_WARNING);
+	$this->triggerError(\'Load Templates : Resource <em>'.$usedTemplateResourceName.'</em> was not added to Dwoo, can not extend <em>'.$usedTemplateResourceIdentifier.'</em>\', E_USER_WARNING);
 }
 if ($tpl === null)
-	$this->triggerError(\'Load Templates : Resource "'.$resource.':'.$identifier.'" was not found.\', E_USER_WARNING);
+	$this->triggerError(\'Load Templates : Resource "'.$usedTemplateResourceName.':'.$usedTemplateResourceIdentifier.'" was not found.\', E_USER_WARNING);
 elseif ($tpl === false)
-	$this->triggerError(\'Load Templates : Resource "'.$resource.'" does not support extends.\', E_USER_WARNING);
-if ($tpl->getUid() != "'.$tpl->getUid().'") { ob_end_clean(); return false; }';
+	$this->triggerError(\'Load Templates : Resource "'.$usedTemplateResourceName.'" does not support extends.\', E_USER_WARNING);
+if ($tpl->getUid() != "'.$usedTemplate->getUid().'") { ob_end_clean(); return false; }';
+        }
     }
 
     return $out;


### PR DESCRIPTION
When the same template is included in different scopes, the plugin function gets defined once but has two different UUIDs. The UUID should not be part of the function name